### PR TITLE
Fix a styleCheck error

### DIFF
--- a/uuids.nimble
+++ b/uuids.nimble
@@ -1,6 +1,6 @@
 [Package]
 name: "uuids"
-version: "0.1.10"
+version: "0.1.11"
 author: "Xored Software, Inc."
 description: "UUID library"
 license: "MIT"

--- a/uuids/urandom.nim
+++ b/uuids/urandom.nim
@@ -16,16 +16,16 @@ when defined(windows):
     proc CryptAcquireContext(
       phProv: ptr HCRYPTPROV, pszContainer: WideCString,
       pszProvider: WideCString, dwProvType: DWORD, dwFlags: DWORD
-    ): WinBool {.importc: "CryptAcquireContextW".}
+    ): WINBOOL {.importc: "CryptAcquireContextW".}
   else:
     proc CryptAcquireContext(
       phProv: ptr HCRYPTPROV, pszContainer: cstring, pszProvider: cstring,
       dwProvType: DWORD, dwFlags: DWORD
-    ): WinBool {.importc: "CryptAcquireContextA".}
+    ): WINBOOL {.importc: "CryptAcquireContextA".}
 
   proc CryptGenRandom(
     hProv: HCRYPTPROV, dwLen: DWORD, pbBuffer: pointer
-  ): WinBool {.importc: "CryptGenRandom".}
+  ): WINBOOL {.importc: "CryptGenRandom".}
 
   {.pop.}
 


### PR DESCRIPTION
This commit also bumps the version - let me know if that's a problem.

---

Before this commit, running `nim c --styleCheck:error` on a file
that imports the `uuids` package would produce an error on Windows.

`WINBOOL` is defined here:
https://github.com/nim-lang/Nim/blob/52cf7280019c/lib/windows/winlean.nim#L33

Fixes: #5