### PR TITLE
urandom: fix for Nim 2.0 by using only `CryptAcquireContextW`

### DIFF
--- a/uuids/urandom.nim
+++ b/uuids/urandom.nim
@@ -12,16 +12,10 @@ when defined(windows):
 
   {.push, stdcall, dynlib: "Advapi32.dll".}
 
-  when useWinUnicode:
-    proc CryptAcquireContext(
-      phProv: ptr HCRYPTPROV, pszContainer: WideCString,
-      pszProvider: WideCString, dwProvType: DWORD, dwFlags: DWORD
-    ): WINBOOL {.importc: "CryptAcquireContextW".}
-  else:
-    proc CryptAcquireContext(
-      phProv: ptr HCRYPTPROV, pszContainer: cstring, pszProvider: cstring,
-      dwProvType: DWORD, dwFlags: DWORD
-    ): WINBOOL {.importc: "CryptAcquireContextA".}
+  proc CryptAcquireContext(
+    phProv: ptr HCRYPTPROV, pszContainer: WideCString,
+    pszProvider: WideCString, dwProvType: DWORD, dwFlags: DWORD
+  ): WINBOOL {.importc: "CryptAcquireContextW".}
 
   proc CryptGenRandom(
     hProv: HCRYPTPROV, dwLen: DWORD, pbBuffer: pointer


### PR DESCRIPTION
Before this commit, compiling `urandom.nim` on Windows with [Nim 2.0][1] would produce an error:

```console
$ nim c --os:windows uuids/urandom.nim
/foo/pragmagic-uuids/uuids/urandom.nim(15, 8) Error: undeclared identifier: 'useWinUnicode'
```

This was because Nim 2.0 [removed the `useWinUnicode` identifier][2].

Fix by always using `CryptAcquireContextW` on Windows.

Fixes: #8

[1]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html
[2]: https://github.com/nim-lang/Nim/commit/612abda4f40b2a0fd8dd0e4ad119c4415b9c34cb

---

I don't have a Windows machine to test this on. This PR may not be sufficient to make the `uuids` package work with Nim 2.0 on Windows.